### PR TITLE
Adds a `monitored-metric` filter for cloudtrail trails.

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -5,6 +5,7 @@
 import json
 import time
 import datetime
+import re
 from botocore.exceptions import ClientError
 from fnmatch import fnmatch
 from dateutil.parser import parse as parse_date
@@ -56,6 +57,10 @@ class Account(ResourceManager):
         global_resource = True
         # fake this for doc gen
         service = "account"
+
+    @property
+    def source_type(self):
+        return 'describe'
 
     @classmethod
     def get_permissions(cls):
@@ -1014,7 +1019,6 @@ class EnableTrail(BaseAction):
                 update_args['Name'] = trail_name
                 client.update_trail(**update_args)
 
-
 @filters.register('has-virtual-mfa')
 class HasVirtualMFA(Filter):
     """Is the account configured with a virtual MFA device?
@@ -1052,7 +1056,6 @@ class HasVirtualMFA(Filter):
 
     def process(self, resources, event=None):
         return list(filter(self.account_has_virtual_mfa, resources))
-
 
 @actions.register('enable-data-events')
 class EnableDataEvents(BaseAction):
@@ -1790,3 +1793,121 @@ class SecHubEnabled(Filter):
         if state == bool(sechub):
             return resources
         return []
+
+@filters.register('alarmed-cloudtrail-patterns')
+class MonitoredCloudtrailMetric(Filter):
+    """Finds cloudtrails with logging and a metric filter. Is a subclass of ValueFilter,
+    filtering the metric filter objects. Optionally, verifies an alarm exists (true by default),
+    and for said alarm, there is atleast one SNS subscription (again, true by default).
+    :example:
+        .. code-block: yaml
+            policies:
+              - name: cloudtrail-trail-with-login-attempts
+                resource: cloudtrail
+                region: us-east-1
+                filters:
+                  - type: monitored-metric
+                    alarm: true
+                    topic-subscription: false
+                    filter: '$.eventName = DeleteTrail'
+    """
+
+    schema = type_schema('alarmed-cloudtrail-patterns', **{
+        'patterns': {'type': 'array'},
+        'topic-subscription': {'type': 'boolean'},
+        'alarm': {'type': 'boolean'}
+    })
+
+    permissions = ('logs:DescribeMetricFilters', 'cloudwatch:DescribeAlarms',
+        'sns:ListSubscriptionsByTopic')
+
+    def find_subscribed_topic_arns(self, session, topicArns, region):
+        sns = session.client('sns', region_name=region)
+        def arn_has_subscriptions(arn):
+            subscriptions = sns.list_subscriptions_by_topic(TopicArn=arn)['Subscriptions']
+            return any(subscriptions)
+        return filter(arn_has_subscriptions, topicArns)
+
+    def all_alarms(self, session, region):
+        client = session.client('cloudwatch', region_name=region)
+        paginator = client.get_paginator('describe_alarms')
+        try:
+            results = paginator.paginate().build_full_result()
+            return results['MetricAlarms']
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                return []
+            else:
+                raise
+
+    def fetch_metric_filters_for_log_group(self, session, groupName, region):
+        logs = session.client('logs', region_name=region)
+        paginator = logs.get_paginator('describe_metric_filters')
+        try:
+            results = paginator.paginate(logGroupName=groupName).build_full_result()
+            return results['metricFilters']
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                return []
+            else:
+                raise
+
+    def alarm_contains_metrics(self, alarm, metrics):
+        pair = (alarm['Namespace'], alarm['MetricName'])
+        return pair in metrics
+
+    def account_matches_filters(self, account):
+        trails = self.manager.get_resource_manager('cloudtrail').resources()
+        return any(filter(self.cloudtrail_matches_filter, trails))
+
+    def text_matches_patterns(self, metric_filter):
+        patterns = self.data['patterns']
+        if 'filterPattern' not in metric_filter:
+            return False
+        text = metric_filter['filterPattern']
+        return all(map(lambda pattern: bool(re.search(pattern, text, flags=re.IGNORECASE)), patterns))
+
+    def cloudtrail_matches_filter(self, trail):
+        logGroupArn = trail.get('CloudWatchLogsLogGroupArn')
+        if not logGroupArn:
+            return False
+        groupName = re.search(':log-group:([^:]+)', logGroupArn).group(1)
+        # When we have a shadow group, we need to process the given region instead of the base.
+        groupRegion = re.search('arn:aws:logs:([^:]+):', logGroupArn).group(1)
+
+        session = local_session(self.manager.session_factory)
+
+        filters = self.fetch_metric_filters_for_log_group(session, groupName, groupRegion)
+        matchingFilters = filter(self.text_matches_patterns, filters)
+        if not matchingFilters:
+            return False
+
+        # We need to filter the list of transformations to those that emit a value, and then put
+        # it into a format we can easily cross compare on.
+        allTransformations = map(lambda filter: filter['metricTransformations'], matchingFilters)
+        transformations = sum(allTransformations, [])
+        emittedMetrics = map(lambda t: (t['metricNamespace'], t['metricName']), transformations)
+        if not emittedMetrics:
+            return False
+
+        consideredSet = emittedMetrics
+
+        if self.data.get('alarm', True):
+            metricAlarms = self.all_alarms(session, groupRegion)
+
+            def alarmFilter(alarm):
+                return self.alarm_contains_metrics(alarm, emittedMetrics)
+            filteredAlarms = filter(alarmFilter, metricAlarms)
+            if not filteredAlarms:
+                return False
+            consideredSet = filteredAlarms
+            if self.data.get('topic-subscription'):
+                alarmSNSTopics = sum(map(lambda alarm: alarm['AlarmActions'], filteredAlarms), [])
+                if not alarmSNSTopics:
+                    return False
+                consideredSet = self.find_subscribed_topic_arns(session, alarmSNSTopics, groupRegion)
+
+        return any(consideredSet)
+
+    def process(self, resources, event=None):
+        return filter(self.account_matches_filters, resources)

--- a/c7n/resources/cloudtrail.py
+++ b/c7n/resources/cloudtrail.py
@@ -4,7 +4,7 @@ import logging
 
 from c7n.actions import Action, BaseAction
 from c7n.exceptions import PolicyValidationError
-from c7n.filters import ValueFilter, Filter, FilterRegistery
+from c7n.filters import ValueFilter, Filter, FilterRegistry, OPERATORS
 from c7n.manager import resources
 from c7n.tags import universal_augment
 from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
@@ -349,3 +349,42 @@ class MonitoredCloudtrailMetric(ValueFilter):
 
     def process(self, resources, event=None):
         return [resource for resource in resources if self.checkResourceMetricFilters(resource)]
+
+@filters.register('in-home-region')
+class InHomeRegionFilter(Filter):
+    """Filters for all cloudtrail trails that are currently in their home region.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: cloudtrail-in-home-region
+                resource: cloudtrail
+                filters:
+                  - type: in-home-region
+                actions:
+                  - delete-global-grants
+    """
+    schema = type_schema('in-home-region')
+
+    def process(self, trails, event=None):
+        session = local_session(self.manager.session_factory)
+        current_region = session.region_name
+        return [t for t in trails if t['HomeRegion'] == current_region]
+
+@CloudTrail.filter_registry.register('trail-status')
+class TrailStatusFilter(ValueFilter):
+    schema = type_schema('trail-status', rinherit=ValueFilter.schema)
+    permissions = ('cloudtrail:GetTrailStatus',)
+
+    def process(self, resources, event=None):
+        client = local_session(self.manager.session_factory).client('cloudtrail')
+        matches = []
+        for item in resources:
+            if 'c7n:TrailStatus' not in item:
+                status = self.manager.retry(client.get_trail_status, Name=item['TrailARN'])
+                item['c7n:TrailStatus'] = status
+            if self.match(item['c7n:TrailStatus']):
+                matches.append(item)
+        return matches

--- a/c7n/resources/cloudtrail.py
+++ b/c7n/resources/cloudtrail.py
@@ -4,15 +4,16 @@ import logging
 
 from c7n.actions import Action, BaseAction
 from c7n.exceptions import PolicyValidationError
-from c7n.filters import ValueFilter, Filter
+from c7n.filters import ValueFilter, Filter, FilterRegistery
 from c7n.manager import resources
 from c7n.tags import universal_augment
 from c7n.query import ConfigSource, DescribeSource, QueryResourceManager, TypeInfo
 from c7n.utils import local_session, type_schema
-
 from .aws import shape_validate, Arn
+import re
 
 log = logging.getLogger('c7n.resources.cloudtrail')
+filters = FilterRegistry('cloudtrail.filters')
 
 
 class DescribeTrail(DescribeSource):
@@ -40,8 +41,7 @@ class CloudTrail(QueryResourceManager):
         'config': ConfigSource
     }
 
-
-@CloudTrail.filter_registry.register('is-shadow')
+@filters.register('is-shadow')
 class IsShadow(Filter):
     """Identify shadow trails (secondary copies), shadow trails
     can't be modified directly, the origin trail needs to be modified.
@@ -69,7 +69,7 @@ class IsShadow(Filter):
         return False
 
 
-@CloudTrail.filter_registry.register('status')
+@filters.register('status')
 class Status(ValueFilter):
     """Filter a cloudtrail by its status.
 
@@ -218,6 +218,7 @@ class SetLogging(Action):
                 client.stop_logging(Name=r['Name'])
 
 
+
 @CloudTrail.action_registry.register('delete')
 class DeleteTrail(BaseAction):
     """ Delete a cloud trail
@@ -251,3 +252,100 @@ class DeleteTrail(BaseAction):
                 client.delete_trail(Name=r['Name'])
             except client.exceptions.TrailNotFoundException:
                 continue
+
+@filters.register('monitored-metric')
+class MonitoredCloudtrailMetric(ValueFilter):
+    """Finds cloudtrails with logging and a metric filter. Is a subclass of ValueFilter,
+    filtering the metric filter objects. Optionally, verifies an alarm exists (true by default),
+    and for said alarm, there is atleast one SNS subscription (again, true by default).
+
+    :example:
+
+        .. code-block: yaml
+
+            policies:
+              - name: cloudtrail-trail-with-login-attempts
+                resource: cloudtrail
+                region: us-east-1
+                filters:
+                  - type: monitored-metric
+                    alarm: true
+                    topic-subscription: false
+                    filter: '$.eventName = DeleteTrail'
+    """
+
+    schema = type_schema('monitored-metric', rinherit=ValueFilter.schema, **{
+        'topic-subscription': {'type': 'boolean'},
+        'alarm': {'type': 'boolean'}
+    })
+
+    permissions = ('logs:DescribeMetricFilters', 'cloudwatch:DescribeAlarms',
+        'sns:ListSubscriptionsByTopic')
+
+    def _filterTopicArnsToSubscribed(self, session, topicArns):
+        sns = session.client('sns')
+
+        def arnHasSubscriptions(arn):
+            subscriptions = sns.list_subscriptions_by_topic(TopicArn=arn)['Subscriptions']
+            return any(subscriptions)
+        return filter(arnHasSubscriptions, topicArns)
+
+    def _allAlarms(self):
+        return self.manager.get_resource_manager('alarm').resources()
+
+    def _metricFiltersForLogGroup(self, session, groupName):
+        logs = session.client('logs')
+        paginator = logs.get_paginator('describe_metric_filters')
+        results = paginator.paginate(logGroupName=groupName).build_full_result()
+        return results['metricFilters']
+
+    def _alarmInMetrics(self, alarm, metrics):
+        pair = (alarm['Namespace'], alarm['MetricName'])
+        return pair in metrics
+
+    def checkResourceMetricFilters(self, resource):
+        logGroupArn = resource.get('CloudWatchLogsLogGroupArn')
+        if not logGroupArn:
+            return False
+
+        session = local_session(self.manager.session_factory)
+
+        groupName = re.search(':log-group:([^:]+)', logGroupArn).group(1)
+        filters = self._metricFiltersForLogGroup(session, groupName)
+        matchingFilters = filter(lambda mf: self.match(mf), filters)
+        if not matchingFilters:
+            return False
+        resource['c7n:matching-metric-filters'] = matchingFilters
+
+        # We need to filter the list of transformations to those that emit a value, and then put
+        # it into a format we can easily cross compare on.
+        allTransformations = map(lambda filter: filter['metricTransformations'], matchingFilters)
+        transformations = sum(allTransformations, [])
+        emittedMetrics = map(lambda t: (t['metricNamespace'], t['metricName']), transformations)
+        if not emittedMetrics:
+            return False
+        resource['c7n:emitted-metric-filters'] = emittedMetrics
+
+        consideredSet = emittedMetrics
+
+        if self.data.get('alarm', True):
+            metricAlarms = self._allAlarms()
+
+            def alarmFilter(alarm):
+                return self._alarmInMetrics(alarm, emittedMetrics)
+            filteredAlarms = filter(alarmFilter, metricAlarms)
+            if not filteredAlarms:
+                return False
+            consideredSet = filteredAlarms
+            resource['c7n:metric-filter-alarms'] = filteredAlarms
+            if self.data.get('topic-subscription'):
+                alarmSNSTopics = sum(map(lambda alarm: alarm['AlarmActions'], filteredAlarms), [])
+                if not alarmSNSTopics:
+                    return False
+                consideredSet = self._filterTopicArnsToSubscribed(session, alarmSNSTopics)
+                resource['c7n:subscribed-metric-filter-alarm-topics'] = consideredSet
+
+        return any(consideredSet)
+
+    def process(self, resources, event=None):
+        return [resource for resource in resources if self.checkResourceMetricFilters(resource)]


### PR DESCRIPTION
This allows us to filter those matching a given metric query (and with logging enabled), so that we can find
and filter trails to make sure we have notifications / alarms on for changes.This allows us to filter those matching a given metric query (and with logging enabled), so that we can find
and filter trails to make sure we have notifications / alarms on for changes.