### PR TITLE
Explicitly set the PR info.

### DIFF
--- a/.github/workflows/branch-sync.yml
+++ b/.github/workflows/branch-sync.yml
@@ -28,3 +28,5 @@ jobs:
         source_branch: master
         destination_branch: stax-vendored-patches
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        pr_title: "Update C7N to Master"
+        pr_body: ":crown: :cloud: Magic!"


### PR DESCRIPTION
This otherwise got the default the name of `init`, which is less than ideal.

:crown: :cloud: magic!