### PR TITLE
Rescue TrailNotFoundException inside data-events trail loop

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -2599,6 +2599,7 @@ class DataEvents(Filter):
 
         event_buckets = {}
         for t in trails:
+          try:
             for events in clients[t.get('HomeRegion')].get_event_selectors(
                     TrailName=t['Name']).get('EventSelectors', ()):
                 if 'DataResources' not in events:
@@ -2608,6 +2609,9 @@ class DataEvents(Filter):
                         continue
                     for b in data_events['Values']:
                         event_buckets[b.rsplit(':')[-1].strip('/')] = t['Name']
+          except ClientError as e:
+            if e.response['Error']['Code'] != 'TrailNotFoundException':
+                raise
         return event_buckets
 
     def process(self, resources, event=None):


### PR DESCRIPTION
If a trail exists in multiple accounts an exception is currently thrown because the organization master account is not the current one.