### PR TITLE
Fix an import conflict when using skip-validation as an option

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -31,7 +31,7 @@ def load(options, path, format=None, validate=True, vars=None):
     if not os.path.exists(path):
         raise IOError("Invalid path for config %r" % path)
 
-    from c7n.schema import validate, StructureParser
+    from c7n.schema import StructureParser, validate as validate_schema
     data = utils.load_file(path, format=format, vars=vars)
 
     structure = StructureParser()
@@ -43,7 +43,7 @@ def load(options, path, format=None, validate=True, vars=None):
         return None
 
     if validate:
-        errors = validate(data)
+        errors = validate_schema(data)
         if errors:
             raise PolicyValidationError(
                 "Failed to validate policy %s \n %s" % (


### PR DESCRIPTION
Refactoring in Jan 2020 moved this around, and lead to a situation
where importing schema validation would overwrite the variable
used to control validation.

Generally this isn't an issue, but in our run mode we have policies files
with 6000+ items, and per-policy validation can take over an hour in said
situation.

This restores the flags value by using an aliased import instead, and
makes it all hunky dory.