### PR TITLE
Improve has-statement support for wildcards + arrays of actions

### DIFF
--- a/c7n/config.py
+++ b/c7n/config.py
@@ -43,6 +43,7 @@ class Config(Bag):
             'output_dir': '',
             'cache_period': 0,
             'dryrun': False,
-            'authorization_file': None})
+            'authorization_file': None,
+            'credential_helper': None})
         d.update(kw)
         return cls(d)

--- a/tests/data/placebo/test_s3_has_statement_wildcard/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_has_statement_wildcard/s3.CreateBucket_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-policy-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "BUBh59aj1IUDmGhDTANjcVAPd0kHCZ7DmvkFeq87A8OXZl7+ab9EBeSu7lepEaih7fqQJVOIhhI=", 
+            "RequestId": "20062D9C9972D843"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_statement_wildcard/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_has_statement_wildcard/s3.DeleteBucket_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "HostId": "XdFLAsCakeeyIL0Jn4/SFlWmkIJCtZ4RqLxBZC8sggvLnWw2jTu0vxPEfibpmszCT1JvGRVZ+bw=", 
+            "RequestId": "3C297A1E9E733A21"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_statement_wildcard/s3.GetBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_has_statement_wildcard/s3.GetBucketPolicy_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "HostId": "N/r54UyuioFB+1JEh4nEgIfbuqiWpayzIIIpHtqGizi5RFZcXhibOGyarc8hJgvg2LB+JsU1L4Q=", 
+            "RequestId": "8E4B0DD43705C703"
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "cf-templates-nyrabrca5x2n-us-east-1"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_statement_wildcard/s3.GetBucketPolicy_2.json
+++ b/tests/data/placebo/test_s3_has_statement_wildcard/s3.GetBucketPolicy_2.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "HostId": "dNEMxpHojUF874nF2mlg5ME/edI981nnx8hSN+Ite3NeaoKdqtRlyt+JfkeV/YuTpU/RVjEKdOc=", 
+            "RequestId": "7FEBB8E0DA3C7084"
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "config-bucket-619193117841"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_statement_wildcard/s3.GetBucketPolicy_3.json
+++ b/tests/data/placebo/test_s3_has_statement_wildcard/s3.GetBucketPolicy_3.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Zebra\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":[\"s3:PutObject\", \"s3:Get*\"],\"Resource\":\"arn:aws:s3:::custodian-policy-test/*\",\"Condition\":{\"StringNotEquals\":{\"s3:x-amz-server-side-encryption\":[\"AES256\",\"aws:kms\"]}}},{\"Sid\":\"Zebra\",\"Effect\":\"Deny\",\"Principal\":\"arn:aws:iam::644160558196:root\",\"Action\":[\"s3:PutObject\", \"s3:Get*\"],\"Resource\":\"arn:aws:s3:::custodian-policy-test/*\"}]}",
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "HostId": "jL1IZT8BmFaliIyAn7834ng9hk11JPgxBLJYNMg2IPtcu8A6MVtzs/Yz6FMO5IVe4exEBQIGvGg=",
+            "RequestId": "2592899758274ED6"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_statement_wildcard/s3.GetBucketPolicy_4.json
+++ b/tests/data/placebo/test_s3_has_statement_wildcard/s3.GetBucketPolicy_4.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Policy": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Sid\":\"AWSCloudTrailAclCheck20131101\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam::113285607260:root\",\"arn:aws:iam::086441151436:root\"]},\"Action\":\"s3:GetBucketAcl\",\"Resource\":\"arn:aws:s3:::hazmat-audit-logs\"},{\"Sid\":\"AWSCloudTrailWrite20131101\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam::113285607260:root\",\"arn:aws:iam::086441151436:root\"]},\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::hazmat-audit-logs/api/AWSLogs/619193117841/*\",\"Condition\":{\"StringEquals\":{\"s3:x-amz-acl\":\"bucket-owner-full-control\"}}}]}", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "e0K7ezq0+FJG7XU3j0XyFdlS9/wss6PTSm2j/FL0qrznFFHE6E2xTmePu0z2X6nvZp/ne28VgwQ=", 
+            "RequestId": "8BF7465CC34BD8C0"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_statement_wildcard/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_has_statement_wildcard/s3.ListBuckets_1.json
@@ -1,0 +1,68 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "k_vertigo", 
+            "ID": "904fc4c4790937100e9eb293a15e6a0a1f265a064888055b43d030034f8881ee"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 35
+                }, 
+                "Name": "cf-templates-nyrabrca5x2n-us-east-1"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 23, 
+                    "minute": 54
+                }, 
+                "Name": "config-bucket-619193117841"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 45, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 18, 
+                    "minute": 15
+                }, 
+                "Name": "custodian-policy-test"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 3, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2013, 
+                    "day": 21, 
+                    "minute": 12
+                }, 
+                "Name": "hazmat-audit-logs"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "N4Ka3KSZO3Y3s5B83Kspi9VvuUEVx9p6UaiQkBxmyslMUZtOQB/75F61oq9wsE1fHn07nK0sMKo=", 
+            "RequestId": "80ED9683CA2CAB57"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_statement_wildcard/s3.ListObjects_1.json
+++ b/tests/data/placebo/test_s3_has_statement_wildcard/s3.ListObjects_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "MaxKeys": 1000, 
+        "Prefix": "", 
+        "Name": "custodian-policy-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "q5PdMSuJxDD6D9rEZMcXpasl5NTJP5CqDVwmQg23waLxzjW2RIS8D/in+ozutEQ0W/jZvMrMGv0=", 
+            "RequestId": "2CA9F6362A4E53BF"
+        }, 
+        "Marker": "", 
+        "EncodingType": "url", 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_s3_has_statement_wildcard/s3.PutBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_has_statement_wildcard/s3.PutBucketPolicy_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "HostId": "DVtRLymbtCcgGHevhBN5d27KUXmZzFfpvdJkNIljMTOJ8zKt2qw517MPhNCSacULO0Yw12KXxzw=", 
+            "RequestId": "96D458223D9AF7EA"
+        }
+    }
+}


### PR DESCRIPTION
We need to match the statement when its one of many, or there are wildcards.

This adds a new filter option, which supports this - without breaking compatibility
with the previous statement matchers.