### PR TITLE
chore: remove guardduty support which as already added upstream

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -357,42 +357,6 @@ class ConfigEnabled(Filter):
             return []
         return resources
 
-@filters.register('guard-duty')
-class GuardDuty(ValueFilter):
-    """Return annotated account resource if guard duty filter matches (on current rgion detector)
-
-    For example to determine if an account has guardduty enabled in the current region:
-
-    .. code-block:: yaml
-
-      policies:
-        - name: without-guardduty
-          resource: account
-          filters:
-            - type: guard-duty
-              key: Enabled
-              value: absent
-    """
-    schema = type_schema('guard-duty', rinherit=ValueFilter.schema)
-
-    permissions = ('guardduty:ListDetectors', 'guardduty:GetDetector')
-
-    def process(self, resources, event=None):
-        account = resources[0]
-        if not account.get('c7n:guard-duty'):
-            client = local_session(
-                self.manager.session_factory).client('guardduty')
-            detectors = client.list_detectors()['DetectorIds']
-            if len(detectors) > 0:
-                details = client.get_detector(DetectorId=detectors[0])
-                account['c7n:guard-duty'] = details
-            else:
-                account['c7n:guard-duty'] = None
-        if self.match(account['c7n:guard-duty']):
-            return resources
-        return []
-
-
 @filters.register('iam-summary')
 class IAMSummary(ValueFilter):
     """Return annotated account resource if iam summary filter matches.

--- a/c7n/resources/guardduty.py
+++ b/c7n/resources/guardduty.py
@@ -14,9 +14,30 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from c7n.manager import resources
-from c7n.query import ChildResourceManager, sources, ChildDescribeSource, TypeInfo
+from c7n.query import QueryResourceManager, ChildResourceManager
+from c7n.query import sources, ChildDescribeSource, TypeInfo
 from c7n.utils import local_session, chunks
 from itertools import chain
+
+
+@resources.register('guardduty-detector')
+class Detector(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'guardduty'
+        enum_spec = ('list_detectors', 'DetectorIds', None)
+        detail_spec = ("get_detector", 'DetectorId', None, None)
+        id = 'DetectorId'
+        name = None
+        date = None
+        dimension = None
+        arn = False
+        config_type = "AWS::GuardDuty::Detector"
+        filter_name = None
+
+    @classmethod
+    def has_arn(self):
+        return False
 
 
 @sources.register('get-guardduty-findings')


### PR DESCRIPTION
Clearing up any duplication from upstream cloud custodian project to make merges easier.